### PR TITLE
Change Add to Whitelist Button to Whitelist Toggle Button

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -16,7 +16,7 @@
         "description": "Context menu item"
     },
     "action_whitelist_domain": {
-        "message": "Whitelist this tab's domain",
+        "message": "Add/Remove tab from Whitelist",
         "description": "Context menu item"
     },
     "action_perm_disable": {

--- a/src/background.js
+++ b/src/background.js
@@ -52,6 +52,7 @@ var doBlock = (url, tabId) => {
 };
 
 var updateIcon = () => {
+	if (currentTabId === undefined){ return; } // this happens when the browser is first opened and the event listener that sets currentTabId isn't called
     var domain = /:\/\/([^/]+)/.exec(tabUrls[currentTabId])[1]; // this line is not original
     var list = settings.get("whitelist_domains"); // this line is not original
     // old: if (tempDisabled) {

--- a/src/background.js
+++ b/src/background.js
@@ -153,6 +153,14 @@ chrome.contextMenus.create({
             settings.set("whitelist_domains", list);
             chrome.tabs.reload(tab.id);
         }
+        else { // If the domain is already in the list, remove it
+            list = list.slice();
+            var index = list.indexOf(domain);
+            if (index === -1) { return; } // this is probably redundant...
+            list.splice(index, 1);
+            settings.set("whitelist_domains", list);
+            chrome.tabs.reload(tab.id);
+        }
     }
 });
 


### PR DESCRIPTION
I made it easier to remove websites from the white list but making the "Whitelist this tab's domain" button in the context menu into a button adds the website to the whitelist if it's not already in the whitelist and removes it if it is.  I've also changed the name of the button to reflect that (Add/Remove tab from Whitelist).  As this is my first time doing anything with browser extensions, I don't know if there's a way to make the name of the button be "Add tab to Whitelist" if it's not already in the whitelist and "Remove tab from Whitelist" if it is, but if you know of a way to do that and you have the time, that would probably be ideal.